### PR TITLE
fix: Ejecución pruebas

### DIFF
--- a/src/tests/test_commands.py
+++ b/src/tests/test_commands.py
@@ -46,13 +46,6 @@ async def client() -> TelegramClient:
     await client.disconnect()
     await client.disconnected
     
-@pytest.fixture(scope="session", autouse=True)
-async def initializer(request):
-    def finalize():
-        p.terminate()
-    p = multiprocessing.Process(target=main.main, args=(os.getenv("PRUEBAS_TOKEN"),))
-    p.start()
-    request.addfinalizer(finalize)
     
 ################## TEST FUNCTIONS ################## 
 @mark.asyncio


### PR DESCRIPTION
Se elimina el arranque de la aplicación al inicio de los tests, ya que de ahora en adelante se utiliza un bot de pruebas desplegado en heroku.